### PR TITLE
Show xp_recompensa field in admin list

### DIFF
--- a/gulango_warrior/exercises/admin.py
+++ b/gulango_warrior/exercises/admin.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
 from .models import Exercise
 
-admin.site.register(Exercise)
+
+@admin.register(Exercise)
+class ExerciseAdmin(admin.ModelAdmin):
+    list_display = ("id", "lesson", "answer_type", "xp_recompensa")


### PR DESCRIPTION
## Summary
- show `xp_recompensa` in the Exercise admin listing

## Testing
- `python3 manage.py check`
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684b4d692848832a9431cdbb1cb02dcf