### PR TITLE
Chamar verificar conquistas após ganhar XP

### DIFF
--- a/gulango_warrior/avatars/models.py
+++ b/gulango_warrior/avatars/models.py
@@ -17,10 +17,17 @@ class Avatar(models.Model):
     moedas = models.IntegerField(default=0)
 
     def ganhar_xp(self, quantidade: int) -> None:
+        """Incrementa o XP do avatar e verifica conquistas."""
+
         self.xp_total += quantidade
         while self.xp_total >= self.nivel * 100:
             self.nivel += 1
         self.save()
+
+        # Importação tardia para evitar dependência circular
+        from progress.utils import verificar_conquistas
+
+        verificar_conquistas(self)
 
     def __str__(self) -> str:
         return f"{self.user.username} - Nível {self.nivel}"

--- a/gulango_warrior/progress/tests.py
+++ b/gulango_warrior/progress/tests.py
@@ -1,3 +1,26 @@
 from django.test import TestCase
 
-# Create your tests here.
+from accounts.models import CustomUser
+from avatars.models import Avatar
+from .models import Conquista, AvatarConquista
+
+
+class GanharXPConquistaTests(TestCase):
+    def test_ganhar_xp_verifica_conquistas(self):
+        user = CustomUser.objects.create_user(username="hero", password="123")
+        avatar = Avatar.objects.create(user=user)
+
+        conquista = Conquista.objects.create(
+            nome="Iniciante",
+            descricao="Ganhe 100 de XP",
+            icone="conquistas/iniciante.png",
+            condicao="xp_total >= 100",
+        )
+
+        avatar.ganhar_xp(100)
+
+        self.assertTrue(
+            AvatarConquista.objects.filter(avatar=avatar, conquista=conquista).exists()
+        )
+        self.assertEqual(avatar.xp_total, 100)
+        self.assertEqual(avatar.nivel, 2)


### PR DESCRIPTION
## Summary
- call `verificar_conquistas` every time the avatar receives XP
- test that gaining XP grants achievements

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684b6813279c832ab163decc5635b404