### PR TITLE
Add achievements section on avatar profile

### DIFF
--- a/gulango_warrior/avatars/templates/avatars/perfil.html
+++ b/gulango_warrior/avatars/templates/avatars/perfil.html
@@ -40,6 +40,45 @@
             margin: 5px 0;
             font-size: 1.2em;
         }
+
+        .conquistas {
+            max-width: 420px;
+            margin: 30px auto;
+            padding: 20px;
+            background-color: rgba(0, 0, 0, 0.6);
+            border: 5px solid #d4af37;
+            border-radius: 10px;
+        }
+
+        .conquistas ul {
+            list-style: none;
+            padding: 0;
+        }
+
+        .conquistas li {
+            display: flex;
+            align-items: center;
+            margin-bottom: 15px;
+        }
+
+        .conquistas li img {
+            width: 50px;
+            height: 50px;
+            object-fit: cover;
+            margin-right: 15px;
+            border-radius: 5px;
+            border: 2px solid #d4af37;
+        }
+
+        .conquistas li h3 {
+            margin: 0;
+            font-size: 1.2em;
+        }
+
+        .conquistas li p {
+            margin: 0;
+            font-size: 0.9em;
+        }
     </style>
 </head>
 <body>
@@ -50,6 +89,23 @@
         <p>Nível: {{ avatar.nivel }}</p>
         <p>XP Total: {{ avatar.xp_total }}</p>
         <p>Moedas: {{ avatar.moedas }}</p>
+    </div>
+
+    <div class="conquistas">
+        <h2>Conquistas Desbloqueadas</h2>
+        <ul>
+            {% for av_conquista in conquistas %}
+            <li>
+                <img src="{{ av_conquista.conquista.icone.url }}" alt="{{ av_conquista.conquista.nome }}">
+                <div>
+                    <h3>{{ av_conquista.conquista.nome }}</h3>
+                    <p>{{ av_conquista.conquista.descricao }}</p>
+                </div>
+            </li>
+            {% empty %}
+            <li>Nenhuma conquista desbloqueada ainda.</li>
+            {% endfor %}
+        </ul>
     </div>
 </body>
 </html>

--- a/gulango_warrior/avatars/views.py
+++ b/gulango_warrior/avatars/views.py
@@ -2,14 +2,21 @@ from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 
 from .models import Avatar
+from progress.models import AvatarConquista
 
 
 @login_required
 def perfil_avatar(request):
     """Exibe os dados do avatar do usuário logado."""
     avatar = Avatar.objects.get(user=request.user)
+    conquistas = (
+        AvatarConquista.objects.filter(avatar=avatar)
+        .select_related("conquista")
+        .order_by("data_desbloqueio")
+    )
     context = {
         "avatar": avatar,
+        "conquistas": conquistas,
     }
     return render(request, "avatars/perfil.html", context)
 


### PR DESCRIPTION
## Summary
- query unlocked achievements in `perfil_avatar`
- show avatar achievements list on profile page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684b68e9bfdc832a815114e03f3dce1c