### PR TITLE
Add mapa_mundi course progress view

### DIFF
--- a/gulango_warrior/courses/templates/courses/mapa_mundi.html
+++ b/gulango_warrior/courses/templates/courses/mapa_mundi.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Mapa Mundi</title>
+</head>
+<body>
+    <h1>Mapa Mundi</h1>
+    <ul>
+        {% for info in cursos %}
+        <li>
+            {{ info.curso.title }} -
+            {% if info.concluido %}
+                Concluído
+            {% elif info.iniciado %}
+                Em progresso ({{ info.concluidas }}/{{ info.total }})
+            {% else %}
+                Não iniciado
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/gulango_warrior/courses/views.py
+++ b/gulango_warrior/courses/views.py
@@ -1,3 +1,35 @@
 from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
 
-# Create your views here.
+from .models import Course, Lesson
+from progress.models import LessonProgress
+
+
+@login_required
+def mapa_mundi(request):
+    """Exibe todos os cursos com o progresso do usuário."""
+    cursos_info = []
+
+    for curso in Course.objects.all():
+        total_aulas = Lesson.objects.filter(course=curso).count()
+        progresso_qs = LessonProgress.objects.filter(
+            user=request.user, lesson__course=curso
+        )
+
+        iniciou = progresso_qs.exists()
+        concluidas = progresso_qs.filter(completed=True).count()
+        concluido = total_aulas > 0 and concluidas == total_aulas
+
+        cursos_info.append(
+            {
+                "curso": curso,
+                "iniciado": iniciou,
+                "concluido": concluido,
+                "concluidas": concluidas,
+                "total": total_aulas,
+            }
+        )
+
+    context = {"cursos": cursos_info}
+    return render(request, "courses/mapa_mundi.html", context)
+


### PR DESCRIPTION
## Summary
- show course progress in new `mapa_mundi` view
- add template for map display

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684b6bcfd650832aa5c7854a714a951d