### PR TITLE
Update course status on mapa_mundi

### DIFF
--- a/gulango_warrior/courses/templates/courses/mapa_mundi.html
+++ b/gulango_warrior/courses/templates/courses/mapa_mundi.html
@@ -10,13 +10,7 @@
         {% for info in cursos %}
         <li>
             {{ info.curso.title }} -
-            {% if info.concluido %}
-                Concluído
-            {% elif info.iniciado %}
-                Em progresso ({{ info.concluidas }}/{{ info.total }})
-            {% else %}
-                Não iniciado
-            {% endif %}
+            {{ info.status }}{% if info.status == 'em andamento' %} ({{ info.concluidas }}/{{ info.total }}){% endif %}
         </li>
         {% endfor %}
     </ul>

--- a/gulango_warrior/courses/views.py
+++ b/gulango_warrior/courses/views.py
@@ -16,15 +16,19 @@ def mapa_mundi(request):
             user=request.user, lesson__course=curso
         )
 
-        iniciou = progresso_qs.exists()
         concluidas = progresso_qs.filter(completed=True).count()
-        concluido = total_aulas > 0 and concluidas == total_aulas
+
+        if not progresso_qs.exists():
+            status = "não iniciado"
+        elif total_aulas > 0 and concluidas == total_aulas:
+            status = "concluído"
+        else:
+            status = "em andamento"
 
         cursos_info.append(
             {
                 "curso": curso,
-                "iniciado": iniciou,
-                "concluido": concluido,
+                "status": status,
                 "concluidas": concluidas,
                 "total": total_aulas,
             }


### PR DESCRIPTION
## Summary
- compute per course progress status in `mapa_mundi` view
- simplify `mapa_mundi.html` to display the status text

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_b_684be5510380832abe64cde1efb03d3c