### PR TITLE
Add medieval NPC response generator

### DIFF
--- a/gulango_warrior/courses/utils.py
+++ b/gulango_warrior/courses/utils.py
@@ -34,3 +34,36 @@ def gerar_resposta_ia(pergunta: str, npc: NPC) -> str:
         return resposta.choices[0].message.content.strip()
     except Exception:
         return "Desculpe, não consegui responder agora."
+
+
+def gerar_resposta_npc(nome_npc: str, pergunta: str) -> str:
+    """Gera uma resposta com tom medieval para o aluno.
+
+    A resposta é produzida pela API da OpenAI. Caso a chave de API
+    não esteja configurada ou ocorra algum erro, uma mensagem padrão é
+    retornada.
+    """
+    if openai is None:
+        return "Desculpe, não foi possível gerar a resposta."
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return "API key não configurada."
+
+    openai.api_key = api_key
+    system_prompt = (
+        f"Você é {nome_npc}, um sábio mestre de magia de um reino medieval. "
+        "Responda de maneira breve e em tom medieval às perguntas dos alunos."
+    )
+
+    try:
+        resposta = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": pergunta},
+            ],
+        )
+        return resposta.choices[0].message.content.strip()
+    except Exception:
+        return "Desculpe, não consegui responder agora."


### PR DESCRIPTION
## Summary
- extend `courses/utils.py` with `gerar_resposta_npc`
- new function uses OpenAI API to answer with a medieval tone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bef6d06a4832aaf770486001dba9f