### PR TITLE
Add conquistas ranking view

### DIFF
--- a/gulango_warrior/avatars/templates/avatars/conquistas_ranking.html
+++ b/gulango_warrior/avatars/templates/avatars/conquistas_ranking.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Hall das Conquistas</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'MedievalSharp', cursive;
+            margin: 0;
+            padding: 40px;
+            background: url('https://cdn.pixabay.com/photo/2017/08/30/12/45/background-2693750_1280.jpg') repeat;
+            color: #2c2c2c;
+        }
+        .ranking {
+            max-width: 600px;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 0.85);
+            border: 5px solid #8b6f47;
+            border-radius: 10px;
+            padding: 20px;
+        }
+        .ranking h1 {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .ranking ul {
+            list-style: none;
+            padding: 0;
+        }
+        .ranking li {
+            display: flex;
+            align-items: center;
+            background: rgba(240, 230, 214, 0.9);
+            border: 2px solid #8b6f47;
+            padding: 10px;
+            margin-bottom: 10px;
+        }
+        .ranking li:first-child {
+            border: 3px solid #d4af37;
+            box-shadow: 0 0 10px #d4af37;
+            background: rgba(255, 215, 0, 0.3);
+        }
+        .ranking li img {
+            width: 60px;
+            height: 60px;
+            object-fit: cover;
+            border-radius: 50%;
+            border: 2px solid #8b6f47;
+            margin-right: 15px;
+        }
+        .rank-info {
+            flex: 1;
+        }
+    </style>
+</head>
+<body>
+    <div class="ranking">
+        <h1>Hall das Conquistas</h1>
+        <ul>
+            {% for avatar in avatares %}
+            <li>
+                <span>{{ forloop.counter }}º</span>
+                <img src="{{ avatar.imagem.url }}" alt="Avatar de {{ avatar.user.username }}">
+                <div class="rank-info">
+                    <strong>{{ avatar.user.username }}</strong><br>
+                    Conquistas: {{ avatar.qtd_conquistas }}
+                </div>
+            </li>
+            {% empty %}
+            <li>Nenhum avatar encontrado.</li>
+            {% endfor %}
+        </ul>
+    </div>
+</body>
+</html>

--- a/gulango_warrior/avatars/urls.py
+++ b/gulango_warrior/avatars/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import perfil_avatar, ranking_geral
+from .views import perfil_avatar, ranking_geral, destaque_conquistas
 
 urlpatterns = [
     path('perfil/', perfil_avatar, name='perfil_avatar'),
     path('ranking/', ranking_geral, name='ranking_geral'),
+    path('conquistas/', destaque_conquistas, name='destaque_conquistas'),
 ]

--- a/gulango_warrior/avatars/views.py
+++ b/gulango_warrior/avatars/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
+from django.db.models import Count
 
 from .models import Avatar
 from progress.models import AvatarConquista
@@ -31,4 +32,19 @@ def ranking_geral(request):
         "avatares": avatares,
     }
     return render(request, "avatars/ranking.html", context)
+
+
+@login_required
+def destaque_conquistas(request):
+    """Exibe os avatares com mais conquistas desbloqueadas."""
+
+    avatares = (
+        Avatar.objects.annotate(qtd_conquistas=Count("avatarconquista"))
+        .order_by("-qtd_conquistas")[:10]
+    )
+
+    context = {
+        "avatares": avatares,
+    }
+    return render(request, "avatars/conquistas_ranking.html", context)
 


### PR DESCRIPTION
## Summary
- show a new ranking for avatars by unlocked achievements
- wire the new view in urls
- add `conquistas_ranking.html` template

## Testing
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684c09e3bf28832a862f34ca40da57e1