### PR TITLE
Add tests for extra apps

### DIFF
--- a/gulango_warrior/accounts/tests.py
+++ b/gulango_warrior/accounts/tests.py
@@ -1,3 +1,17 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import CustomUser
+
+
+class CustomUserModelTests(TestCase):
+    """Tests for the :class:`CustomUser` model."""
+
+    def test_default_not_instructor(self):
+        user = CustomUser.objects.create_user(username="hero", password="123")
+        self.assertFalse(user.is_instructor)
+
+    def test_create_instructor(self):
+        user = CustomUser.objects.create_user(
+            username="mentor", password="123", is_instructor=True
+        )
+        self.assertTrue(user.is_instructor)

--- a/gulango_warrior/avatars/tests.py
+++ b/gulango_warrior/avatars/tests.py
@@ -1,3 +1,37 @@
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from accounts.models import CustomUser
+from .models import Avatar
+
+
+class AvatarModelTests(TestCase):
+    def test_ganhar_xp_sobe_nivel(self):
+        user = CustomUser.objects.create_user(username="player", password="123")
+        avatar = Avatar.objects.create(user=user)
+
+        avatar.ganhar_xp(50)
+        self.assertEqual(avatar.xp_total, 50)
+        self.assertEqual(avatar.nivel, 1)
+
+        avatar.ganhar_xp(60)
+        avatar.refresh_from_db()
+        self.assertEqual(avatar.nivel, 2)
+
+    def test_str(self):
+        user = CustomUser.objects.create_user(username="knight", password="123")
+        avatar = Avatar.objects.create(user=user, nivel=3)
+        self.assertEqual(str(avatar), "knight - Nível 3")
+
+
+class AvatarViewSecurityTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="a", password="b")
+        Avatar.objects.create(user=self.user)
+
+    def test_views_require_login(self):
+        for name in ["perfil_avatar", "ranking_geral", "destaque_conquistas"]:
+            url = reverse(name)
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("/accounts/login/", response["Location"])

--- a/gulango_warrior/courses/tests.py
+++ b/gulango_warrior/courses/tests.py
@@ -1,3 +1,72 @@
 from django.test import TestCase
+from django.urls import reverse
+from unittest.mock import patch
 
-# Create your tests here.
+from accounts.models import CustomUser
+from .models import Course, Lesson, NPC, HistoricoDialogo
+
+
+class CourseViewsTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="p", password="1")
+        self.course = Course.objects.create(
+            title="Magia", description="A", instructor=self.user
+        )
+        self.lesson = Lesson.objects.create(
+            course=self.course,
+            title="Intro",
+            video_url="http://example.com",
+            order=1,
+        )
+
+    def test_mapa_mundi_login_required(self):
+        response = self.client.get(reverse("mapa_mundi"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response["Location"])
+
+    def test_conversar_npc_login_required(self):
+        npc = NPC.objects.create(
+            nome="Guardião",
+            avatar="npcs/g.png",
+            curso=self.course,
+            frase_inicial="Olá",
+            tipo=NPC.FIXO,
+        )
+        response = self.client.get(reverse("conversar_npc", args=[npc.id]))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response["Location"])
+
+    def test_conversar_npc_fixo(self):
+        npc = NPC.objects.create(
+            nome="Guardião",
+            avatar="npcs/g.png",
+            curso=self.course,
+            frase_inicial="Olá",
+            tipo=NPC.FIXO,
+        )
+
+        self.client.login(username="p", password="1")
+        response = self.client.post(
+            reverse("conversar_npc", args=[npc.id]), {"pergunta": "Oi"}
+        )
+        self.assertContains(response, "Olá")
+        self.assertTrue(
+            HistoricoDialogo.objects.filter(usuario=self.user, npc=npc).exists()
+        )
+
+    def test_conversar_npc_ia(self):
+        npc = NPC.objects.create(
+            nome="Mago",
+            avatar="npcs/m.png",
+            curso=self.course,
+            frase_inicial="Oi",
+            tipo=NPC.IA,
+        )
+
+        with patch("courses.utils.gerar_resposta_ia", return_value="resposta"):
+            self.client.login(username="p", password="1")
+            response = self.client.post(
+                reverse("conversar_npc", args=[npc.id]), {"pergunta": "?"}
+            )
+            self.assertContains(response, "resposta")
+

--- a/gulango_warrior/exercises/tests.py
+++ b/gulango_warrior/exercises/tests.py
@@ -1,3 +1,50 @@
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from accounts.models import CustomUser
+from avatars.models import Avatar
+from courses.models import Course, Lesson
+from .models import Exercise
+
+
+class CodeExecutorTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="dev", password="pw")
+        Avatar.objects.create(user=self.user)
+        course = Course.objects.create(
+            title="Curso", description="d", instructor=self.user
+        )
+        lesson = Lesson.objects.create(
+            course=course, title="L1", video_url="http://ex", order=1
+        )
+        self.exercise = Exercise.objects.create(
+            lesson=lesson,
+            question_text="Pergunta",
+            correct_answer="ok\n",
+            answer_type="code",
+            xp_recompensa=5,
+        )
+
+    def test_requires_login(self):
+        response = self.client.get(reverse("code_executor"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response["Location"])
+
+    def test_execute_code_and_gain_xp(self):
+        self.client.login(username="dev", password="pw")
+        code = "print('ok')"
+        response = self.client.post(
+            reverse("code_executor") + f"?exercise_id={self.exercise.id}",
+            {"code": code},
+        )
+        self.assertContains(response, "ok")
+        avatar = Avatar.objects.get(user=self.user)
+        self.assertEqual(avatar.xp_total, 5)
+
+    def test_get_does_not_execute(self):
+        self.client.login(username="dev", password="pw")
+        self.client.get(
+            reverse("code_executor") + f"?exercise_id={self.exercise.id}"
+        )
+        avatar = Avatar.objects.get(user=self.user)
+        self.assertEqual(avatar.xp_total, 0)


### PR DESCRIPTION
## Summary
- add accounts unit tests
- cover avatars XP gain and view security
- test courses NPC conversations
- protect the code executor via new tests

## Testing
- `python gulango_warrior/manage.py test accounts avatars courses exercises progress marketplace -v 2`

------
https://chatgpt.com/codex/tasks/task_b_684c3ccc06a8832a94876ec6ea373c71