### PR TITLE
Personaliza admin de Avatar

### DIFF
--- a/gulango_warrior/avatars/admin.py
+++ b/gulango_warrior/avatars/admin.py
@@ -5,4 +5,12 @@ from .models import Avatar
 
 @admin.register(Avatar)
 class AvatarAdmin(admin.ModelAdmin):
-    list_display = ("user", "classe", "nivel", "xp_total", "moedas")
+    list_display = ("get_user_name", "classe", "nivel", "xp_total", "moedas")
+    list_filter = ("classe",)
+    ordering = ("-xp_total",)
+
+    def get_user_name(self, obj):
+        """Return the avatar owner's full name or username."""
+        return obj.user.get_full_name() or obj.user.username
+
+    get_user_name.short_description = "Nome do usuário"


### PR DESCRIPTION
## Summary
- mostra nome do usuário, classe, nível, XP e moedas no admin
- permite filtrar por classe
- ordena por XP total

## Testing
- `DJANGO_SECRET_KEY=abc python gulango_warrior/manage.py test accounts avatars courses marketplace progress exercises`

------
https://chatgpt.com/codex/tasks/task_b_684c3e7eea88832a86e523698b3595ed