### PR TITLE
Customize Conquista admin

### DIFF
--- a/gulango_warrior/progress/admin.py
+++ b/gulango_warrior/progress/admin.py
@@ -8,7 +8,9 @@ from .models import (
 )
 
 admin.site.register(LessonProgress)
-admin.site.register(Conquista)
+@admin.register(Conquista)
+class ConquistaAdmin(admin.ModelAdmin):
+    list_display = ("nome", "condicao", "avatarconquista_count")
 admin.site.register(AvatarConquista)
 admin.site.register(MissaoDiaria)
 admin.site.register(UsuarioMissao)

--- a/gulango_warrior/progress/models.py
+++ b/gulango_warrior/progress/models.py
@@ -19,6 +19,10 @@ class Conquista(models.Model):
     def __str__(self):
         return self.nome
 
+    def avatarconquista_count(self) -> int:
+        """Return how many avatars have unlocked this achievement."""
+        return self.avatarconquista_set.count()
+
 
 class AvatarConquista(models.Model):
     avatar = models.ForeignKey(


### PR DESCRIPTION
## Summary
- add method in Conquista model to count AvatarConquista
- customize Conquista admin list to show name, condition and unlock count

## Testing
- `python manage.py test --keepdb -v 1` *(fails: Couldn't find 'resposta' in response)*

------
https://chatgpt.com/codex/tasks/task_b_684c5019355c832a9ed9c72cb54d6a88