### PR TITLE
Update admin for HistoricoDialogo

### DIFF
--- a/gulango_warrior/courses/admin.py
+++ b/gulango_warrior/courses/admin.py
@@ -1,7 +1,13 @@
 from django.contrib import admin
 from .models import Course, Lesson, NPC, HistoricoDialogo
 
+
+class HistoricoDialogoAdmin(admin.ModelAdmin):
+    list_display = ("npc", "usuario", "pergunta", "resposta", "data")
+    search_fields = ("usuario__username", "npc__nome")
+    ordering = ["-data"]
+
 admin.site.register(Course)
 admin.site.register(Lesson)
 admin.site.register(NPC)
-admin.site.register(HistoricoDialogo)
+admin.site.register(HistoricoDialogo, HistoricoDialogoAdmin)


### PR DESCRIPTION
## Summary
- customize admin display for HistoricoDialogo
- enable searching by usuário and NPC
- order dialog entries by most recent first

## Testing
- `DJANGO_SECRET_KEY=test python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684c521ef3ec832a807de413cab2d044