### PR TITLE
Add admin dashboard

### DIFF
--- a/gulango_warrior/dashboard/apps.py
+++ b/gulango_warrior/dashboard/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DashboardConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'dashboard'

--- a/gulango_warrior/dashboard/templates/dashboard/admin_dashboard.html
+++ b/gulango_warrior/dashboard/templates/dashboard/admin_dashboard.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Painel Administrativo</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'MedievalSharp', cursive;
+            padding: 40px;
+            color: #2c2c2c;
+            background: url('https://cdn.pixabay.com/photo/2017/08/30/12/45/background-2693750_1280.jpg') repeat;
+        }
+        .cards {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .card {
+            flex: 1 1 200px;
+            background: rgba(255, 255, 255, 0.9);
+            border: 2px solid #8b6f47;
+            padding: 20px;
+            text-align: center;
+        }
+        h2 {
+            margin-top: 0;
+        }
+        ul {
+            list-style: none;
+            padding: 0;
+        }
+        li {
+            background: rgba(240, 230, 214, 0.9);
+            border: 2px solid #8b6f47;
+            padding: 10px;
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Painel Administrativo</h1>
+    <div class="cards">
+        <div class="card">
+            <h2>Usuários</h2>
+            <p>{{ total_users }}</p>
+        </div>
+        <div class="card">
+            <h2>XP Total</h2>
+            <p>{{ total_xp }}</p>
+        </div>
+        <div class="card">
+            <h2>Conquistas</h2>
+            <p>{{ total_conquistas }}</p>
+        </div>
+        <div class="card">
+            <h2>Moedas</h2>
+            <p>{{ total_moedas }}</p>
+        </div>
+    </div>
+    <h2>Top 3 Jogadores</h2>
+    <ul>
+        {% for avatar in top_players %}
+        <li>{{ forloop.counter }}º {{ avatar.user.username }} - Nível {{ avatar.nivel }} - XP {{ avatar.xp_total }}</li>
+        {% empty %}
+        <li>Nenhum jogador encontrado.</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/gulango_warrior/dashboard/urls.py
+++ b/gulango_warrior/dashboard/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import admin_dashboard
+
+urlpatterns = [
+    path('', admin_dashboard, name='admin_dashboard'),
+]

--- a/gulango_warrior/dashboard/views.py
+++ b/gulango_warrior/dashboard/views.py
@@ -1,0 +1,27 @@
+from django.contrib.admin.views.decorators import staff_member_required
+from django.db.models import Sum
+from django.shortcuts import render
+
+from accounts.models import CustomUser
+from avatars.models import Avatar
+from progress.models import AvatarConquista
+
+
+@staff_member_required
+def admin_dashboard(request):
+    """Display overall game statistics for administrators."""
+
+    total_users = CustomUser.objects.count()
+    total_xp = Avatar.objects.aggregate(total=Sum('xp_total')).get('total') or 0
+    total_conquistas = AvatarConquista.objects.count()
+    total_moedas = Avatar.objects.aggregate(total=Sum('moedas')).get('total') or 0
+    top_players = Avatar.objects.select_related('user').order_by('-xp_total')[:3]
+
+    context = {
+        'total_users': total_users,
+        'total_xp': total_xp,
+        'total_conquistas': total_conquistas,
+        'total_moedas': total_moedas,
+        'top_players': top_players,
+    }
+    return render(request, 'dashboard/admin_dashboard.html', context)

--- a/gulango_warrior/gulango_warrior/settings.py
+++ b/gulango_warrior/gulango_warrior/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'progress',
     'avatars',
     'marketplace',
+    'dashboard',
 ]
 
 MIDDLEWARE = [

--- a/gulango_warrior/gulango_warrior/urls.py
+++ b/gulango_warrior/gulango_warrior/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     path('marketplace/', include('marketplace.urls')),
     path('courses/', include('courses.urls')),
     path('progress/', include('progress.urls')),
+    path('dashboard/', include('dashboard.urls')),
 ]


### PR DESCRIPTION
## Summary
- add dashboard app with admin_dashboard view
- show global user/XP/conquista/moeda stats and top players
- include dashboard in settings and URLs
- rustic themed template with statistic cards

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684c52e78d80832aa7b945cca7b45a76