### PR TITLE
Add admin dashboard route and link

### DIFF
--- a/gulango_warrior/dashboard/templates/admin/base_site.html
+++ b/gulango_warrior/dashboard/templates/admin/base_site.html
@@ -1,0 +1,14 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<div id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></div>
+{% if user.is_anonymous %}
+  {% include "admin/color_theme_toggle.html" %}
+{% endif %}
+{% endblock %}
+
+{% block nav-global %}
+    <a href="{% url 'admin_dashboard' %}">Painel do Jogo</a>
+{% endblock %}

--- a/gulango_warrior/dashboard/urls.py
+++ b/gulango_warrior/dashboard/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from .views import admin_dashboard
 
 urlpatterns = [
-    path('', admin_dashboard, name='admin_dashboard'),
+    path('', admin_dashboard, name='dashboard_home'),
 ]

--- a/gulango_warrior/gulango_warrior/urls.py
+++ b/gulango_warrior/gulango_warrior/urls.py
@@ -17,7 +17,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+from dashboard.views import admin_dashboard
+
 urlpatterns = [
+    path('admin/dashboard/', admin_dashboard, name='admin_dashboard'),
     path('admin/', admin.site.urls),
     path('exercises/', include('exercises.urls')),
     path('avatars/', include('avatars.urls')),


### PR DESCRIPTION
## Summary
- route `/admin/dashboard/` to the existing `admin_dashboard` view
- rename local dashboard route to avoid reverse conflict
- customize `admin/base_site.html` to show a link to the dashboard

## Testing
- `pytest -q`
- `python gulango_warrior/manage.py check`


------
https://chatgpt.com/codex/tasks/task_b_684c53a4d870832aa9979033a194e73c