### PR TITLE
Implement course completion notifications

### DIFF
--- a/gulango_warrior/avatars/models.py
+++ b/gulango_warrior/avatars/models.py
@@ -31,7 +31,7 @@ class Avatar(models.Model):
         enviar_notificacao(
             self.user,
             "Ganho de XP",
-            f"Você ganhou {quantidade} XP.",
+            f"Você ganhou +{quantidade} XP por concluir uma missão!",
             Notificacao.TIPO_XP,
         )
 
@@ -39,7 +39,7 @@ class Avatar(models.Model):
             enviar_notificacao(
                 self.user,
                 "Subiu de nível",
-                f"Você alcançou o nível {self.nivel}!",
+                f"Parabéns! Você alcançou o nível {self.nivel}!",
                 Notificacao.TIPO_NIVEL,
             )
 

--- a/gulango_warrior/exercises/views.py
+++ b/gulango_warrior/exercises/views.py
@@ -5,7 +5,10 @@ from django.contrib.auth.decorators import login_required
 import io
 import sys
 
+from django.utils import timezone
 from avatars.models import Avatar
+from progress.models import LessonProgress
+from progress.utils import verificar_curso_concluido
 from .models import Exercise
 
 @csrf_exempt
@@ -36,6 +39,16 @@ def code_executor(request):
             avatar = Avatar.objects.get(user=request.user)
             avatar.ganhar_xp(exercise.xp_recompensa)
             xp_message = f"Voc\u00ea ganhou {exercise.xp_recompensa} XP!"
+
+            lp, _ = LessonProgress.objects.get_or_create(
+                user=request.user, lesson=exercise.lesson
+            )
+            if not lp.completed:
+                lp.completed = True
+                lp.completed_at = timezone.now()
+                lp.save()
+
+            verificar_curso_concluido(request.user, exercise.lesson.course)
 
     context = {
         "output": output,

--- a/gulango_warrior/progress/utils.py
+++ b/gulango_warrior/progress/utils.py
@@ -146,7 +146,7 @@ def verificar_conquistas(avatar: Avatar) -> None:
             enviar_notificacao(
                 avatar.user,
                 "Conquista desbloqueada",
-                f"Você desbloqueou a conquista {conquista.nome}!",
+                f"Nova conquista desbloqueada: {conquista.nome}!",
                 Notificacao.TIPO_CONQUISTA,
             )
 
@@ -171,6 +171,33 @@ def verificar_missoes_automaticas(
             avatar.save()
             usuario_missao.concluida = True
             usuario_missao.save()
+
+
+def verificar_curso_concluido(usuario, curso) -> None:
+    """Envia uma notificação caso o usuário tenha finalizado todas as aulas do curso."""
+
+    from courses.models import Lesson
+
+    total = Lesson.objects.filter(course=curso).count()
+    if total == 0:
+        return
+
+    concluido = LessonProgress.objects.filter(
+        user=usuario, lesson__course=curso, completed=True
+    ).count()
+    if concluido == total:
+        ja_notificado = Notificacao.objects.filter(
+            usuario=usuario,
+            titulo="Curso concluído",
+            mensagem__icontains=curso.title,
+        ).exists()
+        if not ja_notificado:
+            enviar_notificacao(
+                usuario,
+                "Curso concluído",
+                "Curso concluído! Você dominou as terras de Golandor!",
+                Notificacao.TIPO_SISTEMA,
+            )
 
 
 def gerar_feedback_ia(avatar: Avatar) -> str:


### PR DESCRIPTION
## Summary
- notify user on XP gain and level-up
- notify when unlocking an achievement
- track lesson progress and course completion
- send course completion notifications

## Testing
- `DJANGO_SECRET_KEY=test python gulango_warrior/manage.py test progress exercises courses avatars accounts dashboard marketplace`

------
https://chatgpt.com/codex/tasks/task_b_684c5afc3f60832a8709cec2c6edb850