### PR TITLE
Track XP per language

### DIFF
--- a/gulango_warrior/avatars/models.py
+++ b/gulango_warrior/avatars/models.py
@@ -17,16 +17,28 @@ class Avatar(models.Model):
     xp_total = models.IntegerField(default=0)
     moedas = models.IntegerField(default=0)
 
-    def ganhar_xp(self, quantidade: int) -> None:
-        """Incrementa o XP do avatar e dispara notificações."""
+    def ganhar_xp(self, quantidade: int, linguagem: str | None = None) -> None:
+        """Incrementa o XP do avatar, atualizando conquistas e progresso.
 
-        from progress.utils import verificar_conquistas, enviar_notificacao
+        Se ``linguagem`` for fornecida, o progresso do usuário na
+        :class:`~progress.models.ProgressoPorLinguagem` correspondente é
+        criado ou atualizado com o XP recebido.
+        """
+
+        from progress.utils import (
+            verificar_conquistas,
+            enviar_notificacao,
+            atualizar_progresso_linguagem,
+        )
 
         nivel_anterior = self.nivel
         self.xp_total += quantidade
         while self.xp_total >= self.nivel * 100:
             self.nivel += 1
         self.save()
+
+        if linguagem:
+            atualizar_progresso_linguagem(self.user, linguagem, quantidade)
 
         enviar_notificacao(
             self.user,

--- a/gulango_warrior/exercises/tests.py
+++ b/gulango_warrior/exercises/tests.py
@@ -5,6 +5,7 @@ from accounts.models import CustomUser
 from avatars.models import Avatar
 from courses.models import Course, Lesson
 from .models import Exercise
+from progress.models import ProgressoPorLinguagem
 
 
 class CodeExecutorTests(TestCase):
@@ -43,6 +44,10 @@ class CodeExecutorTests(TestCase):
         self.assertContains(response, "ok")
         avatar = Avatar.objects.get(user=self.user)
         self.assertEqual(avatar.xp_total, 5)
+        progresso = ProgressoPorLinguagem.objects.get(
+            usuario=self.user, linguagem=Course.LING_GOLANG
+        )
+        self.assertEqual(progresso.xp_total, 5)
 
     def test_get_does_not_execute(self):
         self.client.login(username="dev", password="pw")
@@ -51,3 +56,8 @@ class CodeExecutorTests(TestCase):
         )
         avatar = Avatar.objects.get(user=self.user)
         self.assertEqual(avatar.xp_total, 0)
+        self.assertFalse(
+            ProgressoPorLinguagem.objects.filter(
+                usuario=self.user, linguagem=Course.LING_GOLANG
+            ).exists()
+        )

--- a/gulango_warrior/exercises/views.py
+++ b/gulango_warrior/exercises/views.py
@@ -37,7 +37,8 @@ def code_executor(request):
 
         if exercise and output.strip() == exercise.correct_answer.strip():
             avatar = Avatar.objects.get(user=request.user)
-            avatar.ganhar_xp(exercise.xp_recompensa)
+            linguagem = exercise.lesson.course.linguagem
+            avatar.ganhar_xp(exercise.xp_recompensa, linguagem=linguagem)
             xp_message = f"Voc\u00ea ganhou {exercise.xp_recompensa} XP!"
 
             lp, _ = LessonProgress.objects.get_or_create(

--- a/gulango_warrior/progress/views.py
+++ b/gulango_warrior/progress/views.py
@@ -22,7 +22,8 @@ def missoes_do_dia(request):
             usuario=request.user, missao=missao, data=hoje
         )
         if not usuario_missao.concluida and _avaliar_condicao(missao.condicao, avatar):
-            avatar.ganhar_xp(missao.xp_recompensa)
+            linguagem = request.POST.get("linguagem")
+            avatar.ganhar_xp(missao.xp_recompensa, linguagem=linguagem)
             avatar.moedas += missao.moedas_recompensa
             avatar.save()
             usuario_missao.concluida = True


### PR DESCRIPTION
## Summary
- update avatar XP method to store progress per language
- track per-language XP during code exercises and missions
- ensure automatic missions can credit language XP
- test language progress updates

## Testing
- `DJANGO_SECRET_KEY=test python manage.py test -v 1`

------
https://chatgpt.com/codex/tasks/task_b_684c5f597464832a9c0d2cbe53de38cd