### PR TITLE
Add PDF certificate generation utility

### DIFF
--- a/gulango_warrior/requirements.txt
+++ b/gulango_warrior/requirements.txt
@@ -1,3 +1,5 @@
 Django>=5.2
 Pillow
 openai
+reportlab
+python-dotenv


### PR DESCRIPTION
## Summary
- add reportlab and python-dotenv to requirements
- implement `gerar_certificado_pdf` to generate themed PDF certificates

## Testing
- `python manage.py test progress -v 1`

------
https://chatgpt.com/codex/tasks/task_b_684c8ff25834832aa18eedbcba631c78