### PR TITLE
Implement duelos_usuario API

### DIFF
--- a/gulango_warrior/gulango_warrior/settings.py
+++ b/gulango_warrior/gulango_warrior/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'accounts',
     'courses',
     'exercises',

--- a/gulango_warrior/progress/urls.py
+++ b/gulango_warrior/progress/urls.py
@@ -6,6 +6,7 @@ from .views import (
     painel_linguagens,
     emitir_certificado,
     ver_certificado,
+    duelos_usuario,
 )
 
 urlpatterns = [
@@ -24,4 +25,5 @@ urlpatterns = [
         ver_certificado,
         name="ver_certificado",
     ),
+    path("duelos/", duelos_usuario.as_view(), name="duelos_usuario"),
 ]

--- a/gulango_warrior/requirements.txt
+++ b/gulango_warrior/requirements.txt
@@ -3,3 +3,4 @@ Pillow
 openai
 reportlab
 python-dotenv
+djangorestframework


### PR DESCRIPTION
## Summary
- add `djangorestframework` dependency
- enable `rest_framework` in installed apps
- implement `duelos_usuario` DRF API view
- expose API endpoint in progress app

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684ca0d741dc832a9493cad8b4aa4922