### PR TITLE
Implement guild creation view

### DIFF
--- a/gulango_warrior/guildas/templates/guildas/criar_guilda.html
+++ b/gulango_warrior/guildas/templates/guildas/criar_guilda.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Criar Guilda</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 30px;
+            background: #f2f2f2;
+        }
+        form {
+            max-width: 400px;
+            margin: 0 auto;
+            background: #fff;
+            padding: 20px;
+            border: 2px solid #ccc;
+        }
+        input, textarea {
+            width: 100%;
+            margin-bottom: 10px;
+        }
+        button {
+            padding: 10px 20px;
+            background: #DAA520;
+            border: none;
+            cursor: pointer;
+        }
+        .msg {
+            text-align: center;
+            margin-bottom: 15px;
+            color: green;
+        }
+        .erro {
+            text-align: center;
+            margin-bottom: 15px;
+            color: red;
+        }
+    </style>
+</head>
+<body>
+    <h1>Criar Guilda</h1>
+    {% if mensagem %}
+        <p class="msg">{{ mensagem }}</p>
+    {% endif %}
+    {% if erro %}
+        <p class="erro">{{ erro }}</p>
+    {% endif %}
+    <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        <input type="text" name="nome" placeholder="Nome" required>
+        <textarea name="descricao" placeholder="Descrição" required></textarea>
+        <input type="file" name="brasao" required>
+        <button type="submit">Criar</button>
+    </form>
+</body>
+</html>

--- a/gulango_warrior/guildas/tests.py
+++ b/gulango_warrior/guildas/tests.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from accounts.models import CustomUser
+from .models import Guilda, MembroGuilda
+
+
+class CriarGuildaViewTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="guerreiro", password="123")
+
+    def test_login_required(self):
+        response = self.client.get(reverse("criar_guilda"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response["Location"])
+
+    def test_criar_guilda(self):
+        self.client.login(username="guerreiro", password="123")
+        with open(__file__, 'rb') as f:
+            response = self.client.post(
+                reverse("criar_guilda"),
+                {
+                    "nome": "Legiao",
+                    "descricao": "Bravos",
+                    "brasao": f,
+                },
+            )
+        self.assertRedirects(response, reverse("criar_guilda"))
+        guilda = Guilda.objects.get(nome="Legiao")
+        self.assertEqual(guilda.lider, self.user)
+        self.assertTrue(MembroGuilda.objects.filter(usuario=self.user, guilda=guilda, cargo=MembroGuilda.CARGO_LIDER).exists())
+
+    def test_ja_e_membro(self):
+        guilda = Guilda.objects.create(nome="G1", descricao="D", brasao="b.png", lider=self.user)
+        MembroGuilda.objects.create(usuario=self.user, guilda=guilda, cargo=MembroGuilda.CARGO_LIDER)
+        self.client.login(username="guerreiro", password="123")
+        response = self.client.post(reverse("criar_guilda"), {"nome": "X", "descricao": "Y"})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "já pertence")

--- a/gulango_warrior/guildas/urls.py
+++ b/gulango_warrior/guildas/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import criar_guilda
+
+urlpatterns = [
+    path('criar/', criar_guilda, name='criar_guilda'),
+]

--- a/gulango_warrior/guildas/views.py
+++ b/gulango_warrior/guildas/views.py
@@ -1,0 +1,36 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect, render
+
+from .models import Guilda, MembroGuilda
+
+
+@login_required
+def criar_guilda(request):
+    """Permite que o usuário crie uma guilda se não fizer parte de nenhuma."""
+
+    ja_membro = MembroGuilda.objects.filter(usuario=request.user).exists()
+    mensagem = request.session.pop("mensagem_guilda", None)
+
+    if ja_membro:
+        return render(request, "guildas/criar_guilda.html", {"erro": "Você já pertence a uma guilda.", "mensagem": mensagem})
+
+    if request.method == "POST":
+        nome = request.POST.get("nome", "")
+        descricao = request.POST.get("descricao", "")
+        brasao = request.FILES.get("brasao")
+
+        guilda = Guilda.objects.create(
+            nome=nome,
+            descricao=descricao,
+            brasao=brasao,
+            lider=request.user,
+        )
+        MembroGuilda.objects.create(
+            usuario=request.user,
+            guilda=guilda,
+            cargo=MembroGuilda.CARGO_LIDER,
+        )
+        request.session["mensagem_guilda"] = "Guilda criada com sucesso!"
+        return redirect("criar_guilda")
+
+    return render(request, "guildas/criar_guilda.html", {"mensagem": mensagem})

--- a/gulango_warrior/gulango_warrior/urls.py
+++ b/gulango_warrior/gulango_warrior/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('exercises/', include('exercises.urls')),
     path('avatars/', include('avatars.urls')),
     path('marketplace/', include('marketplace.urls')),
+    path('guildas/', include('guildas.urls')),
     path('courses/', include('courses.urls')),
     path('notificacoes/', include('notificacoes.urls')),
     path('progress/', include('progress.urls')),


### PR DESCRIPTION
## Summary
- add `criar_guilda` view and url configuration
- allow logged users to create a guild and become leader
- expose guild URL in project routes
- add HTML template for guild creation
- test guild creation logic

## Testing
- `python manage.py test --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_b_684ca4885004832aa580cd7fc3c04d0c