### PR TITLE
Add guild profile view

### DIFF
--- a/gulango_warrior/guildas/templates/guildas/perfil_guilda.html
+++ b/gulango_warrior/guildas/templates/guildas/perfil_guilda.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Perfil da Guilda</title>
+    <style>
+        body {
+            font-family: 'Georgia', serif;
+            background: #f4f0e6;
+            padding: 40px;
+        }
+        .guilda {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .guilda img {
+            max-width: 200px;
+            border: 4px solid #8b6f47;
+            border-radius: 5px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            padding: 10px;
+            border: 1px solid #8b6f47;
+        }
+        th {
+            background: #d4af37;
+        }
+    </style>
+</head>
+<body>
+    <div class="guilda">
+        <h1>{{ guilda.nome }}</h1>
+        <img src="{{ guilda.brasao.url }}" alt="Brasão da guilda">
+        <p>XP Total da Guilda: {{ xp_total }}</p>
+    </div>
+    <table>
+        <thead>
+            <tr>
+                <th>Membro</th>
+                <th>Cargo</th>
+                <th>XP</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for info in membros %}
+            <tr>
+                <td>{{ info.membro.usuario.username }}</td>
+                <td>{{ info.membro.cargo }}</td>
+                <td>{{ info.xp }}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="3">Nenhum membro encontrado.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/gulango_warrior/guildas/urls.py
+++ b/gulango_warrior/guildas/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import perfil_guilda
+
+urlpatterns = [
+    path('perfil/<int:guilda_id>/', perfil_guilda, name='perfil_guilda'),
+]

--- a/gulango_warrior/guildas/views.py
+++ b/gulango_warrior/guildas/views.py
@@ -1,0 +1,34 @@
+from django.shortcuts import get_object_or_404, render
+from django.contrib.auth.decorators import login_required
+from django.db.models import Sum
+
+from .models import Guilda, MembroGuilda
+from avatars.models import Avatar
+
+
+@login_required
+def perfil_guilda(request, guilda_id: int):
+    """Exibe detalhes de uma guilda e de seus membros."""
+
+    guilda = get_object_or_404(Guilda, pk=guilda_id)
+    membros = (
+        MembroGuilda.objects.filter(guilda=guilda)
+        .select_related("usuario__avatar")
+        .order_by("-usuario__avatar__xp_total")
+    )
+
+    membros_info = []
+    xp_total = 0
+    for membro in membros:
+        avatar = getattr(membro.usuario, "avatar", None)
+        xp = avatar.xp_total if avatar else 0
+        membros_info.append({"membro": membro, "xp": xp})
+        xp_total += xp
+
+    context = {
+        "guilda": guilda,
+        "membros": membros_info,
+        "xp_total": xp_total,
+    }
+    return render(request, "guildas/perfil_guilda.html", context)
+

--- a/gulango_warrior/gulango_warrior/urls.py
+++ b/gulango_warrior/gulango_warrior/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('exercises/', include('exercises.urls')),
     path('avatars/', include('avatars.urls')),
     path('marketplace/', include('marketplace.urls')),
+    path('guildas/', include('guildas.urls')),
     path('courses/', include('courses.urls')),
     path('notificacoes/', include('notificacoes.urls')),
     path('progress/', include('progress.urls')),


### PR DESCRIPTION
## Summary
- implement `perfil_guilda` view
- wire up `guildas` URLs and templates
- include guild URLs in the project

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684ca6f6d6a8832a9c8a4e4e06f990db