### PR TITLE
Add guild ranking view

### DIFF
--- a/gulango_warrior/guildas/templates/guildas/ranking.html
+++ b/gulango_warrior/guildas/templates/guildas/ranking.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Ranking das Guildas</title>
+    <style>
+        body {
+            font-family: 'MedievalSharp', cursive;
+            margin: 0;
+            padding: 40px;
+            background: url('https://cdn.pixabay.com/photo/2017/08/30/12/45/background-2693750_1280.jpg') repeat;
+            color: #2c2c2c;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: rgba(255, 255, 255, 0.85);
+            border: 5px solid #8b6f47;
+        }
+        th, td {
+            padding: 10px;
+            border: 1px solid #8b6f47;
+            text-align: left;
+        }
+        th {
+            background: #d4af37;
+        }
+        tr:first-child td {
+            background: rgba(255, 215, 0, 0.3);
+            font-weight: bold;
+        }
+        img.brasao {
+            width: 60px;
+            height: 60px;
+            object-fit: cover;
+            border: 2px solid #8b6f47;
+        }
+    </style>
+</head>
+<body>
+    <h1>Ranking das Guildas</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Brasão</th>
+                <th>Guilda</th>
+                <th>Membros</th>
+                <th>XP Total</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for g in guildas %}
+            <tr>
+                <td>{{ forloop.counter }}</td>
+                <td><img class="brasao" src="{{ g.brasao.url }}" alt="Brasão"></td>
+                <td>{{ g.nome }}</td>
+                <td>{{ g.num_membros }}</td>
+                <td>{{ g.xp_total }}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="5">Nenhuma guilda encontrada.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/gulango_warrior/guildas/urls.py
+++ b/gulango_warrior/guildas/urls.py
@@ -1,9 +1,8 @@
 from django.urls import path
-from .views import criar_guilda
-from .views import perfil_guilda
+from .views import criar_guilda, perfil_guilda, ranking_guildas
 
 urlpatterns = [
     path('perfil/<int:guilda_id>/', perfil_guilda, name='perfil_guilda'),
     path('criar/', criar_guilda, name='criar_guilda'),
-
-
+    path('ranking/', ranking_guildas, name='ranking_guildas'),
+]


### PR DESCRIPTION
## Summary
- implement `ranking_guildas` view and URL
- include guild ranking template
- add dependency installation for tests

## Testing
- `python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_b_684ca952c108832aa6f3a329c6b0c486