### PR TITLE
Add comprar_skin function

### DIFF
--- a/gulango_warrior/avatars/tests.py
+++ b/gulango_warrior/avatars/tests.py
@@ -63,3 +63,54 @@ class SkinUsuarioModelTests(TestCase):
 
         self.assertTrue(SkinUsuario.objects.filter(id=skin_usuario.id).exists())
         self.assertEqual(str(skin_usuario), "u - Robe Vermelho")
+
+
+class ComprarSkinTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="buyer", password="123")
+        self.avatar = Avatar.objects.create(user=self.user, moedas=20)
+        self.skin1 = SkinVisual.objects.create(
+            nome="Armadura A",
+            tipo=SkinVisual.TIPO_AVATAR,
+            imagem="skins/a.png",
+            preco_moedas=10,
+            classe_restrita="todas",
+        )
+        self.skin2 = SkinVisual.objects.create(
+            nome="Armadura B",
+            tipo=SkinVisual.TIPO_AVATAR,
+            imagem="skins/b.png",
+            preco_moedas=5,
+            classe_restrita="todas",
+        )
+
+    def test_compra_primeira_skin_em_uso(self):
+        from .utils import comprar_skin
+
+        resultado = comprar_skin(self.user, self.skin1)
+        self.assertTrue(resultado)
+        self.avatar.refresh_from_db()
+        self.assertEqual(self.avatar.moedas, 10)
+        skin_usuario = SkinUsuario.objects.get(usuario=self.user, skin=self.skin1)
+        self.assertTrue(skin_usuario.em_uso)
+
+    def test_compra_segunda_skin_nao_em_uso(self):
+        from .utils import comprar_skin
+
+        comprar_skin(self.user, self.skin1)
+        self.avatar.refresh_from_db()
+        resultado = comprar_skin(self.user, self.skin2)
+        self.assertTrue(resultado)
+        skin_usuario = SkinUsuario.objects.get(usuario=self.user, skin=self.skin2)
+        self.assertFalse(skin_usuario.em_uso)
+
+    def test_compra_sem_moedas(self):
+        from .utils import comprar_skin
+
+        self.avatar.moedas = 5
+        self.avatar.save()
+        resultado = comprar_skin(self.user, self.skin1)
+        self.assertFalse(resultado)
+        self.assertFalse(
+            SkinUsuario.objects.filter(usuario=self.user, skin=self.skin1).exists()
+        )

--- a/gulango_warrior/avatars/utils.py
+++ b/gulango_warrior/avatars/utils.py
@@ -1,0 +1,29 @@
+"""Utility functions for the avatars app."""
+
+from .models import Avatar, SkinVisual, SkinUsuario
+from accounts.models import CustomUser
+
+
+def comprar_skin(usuario: CustomUser, skin: SkinVisual) -> bool:
+    """Compra uma ``skin`` para ``usuario`` se houver moedas suficientes.
+
+    Deduz o valor da skin do avatar, adiciona um registro ``SkinUsuario`` e
+    define ``em_uso`` caso seja a primeira skin desse tipo para o usuário.
+
+    Retorna ``True`` em caso de sucesso, ``False`` caso o usuário não tenha
+    moedas suficientes.
+    """
+
+    avatar = Avatar.objects.get(user=usuario)
+    if avatar.moedas < skin.preco_moedas:
+        return False
+
+    avatar.moedas -= skin.preco_moedas
+    avatar.save()
+
+    primeira = not SkinUsuario.objects.filter(
+        usuario=usuario, skin__tipo=skin.tipo
+    ).exists()
+
+    SkinUsuario.objects.create(usuario=usuario, skin=skin, em_uso=primeira)
+    return True


### PR DESCRIPTION
## Summary
- add `comprar_skin` utility to handle skin purchases
- test buying skins in several scenarios

## Testing
- `pip install -r gulango_warrior/requirements.txt`
- `python gulango_warrior/manage.py test accounts avatars courses marketplace progress guildas exercises`

------
https://chatgpt.com/codex/tasks/task_b_684cabdf25cc832ab9c7dd7ea4fd671d