### PR TITLE
Add loja_skins view

### DIFF
--- a/gulango_warrior/avatars/templates/avatars/loja_skins.html
+++ b/gulango_warrior/avatars/templates/avatars/loja_skins.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Loja de Skins</title>
+</head>
+<body>
+    <h1>Loja de Skins</h1>
+    <p>Moedas: {{ avatar.moedas }}</p>
+    <ul>
+        {% for info in skins_info %}
+        <li>
+            <h2>{{ info.skin.nome }}</h2>
+            <img src="{{ info.skin.imagem.url }}" alt="{{ info.skin.nome }}">
+            <p>Preço: {{ info.skin.preco_moedas }}</p>
+            <p>Classe permitida: {{ info.skin.classe_restrita }}</p>
+            {% if info.ja_possui %}
+                <p>Você já possui esta skin.</p>
+            {% elif info.pode_comprar %}
+                <p>Você pode comprar esta skin.</p>
+            {% else %}
+                <p>Você não pode comprar esta skin.</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/gulango_warrior/avatars/tests.py
+++ b/gulango_warrior/avatars/tests.py
@@ -198,3 +198,40 @@ class InventarioSkinsViewTests(TestCase):
         self.assertEqual(len(skins), 2)
         self.assertTrue(any(su.em_uso for su in skins))
 
+
+class LojaSkinsViewTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username="shop", password="123")
+        self.avatar = Avatar.objects.create(user=self.user, classe="mago", moedas=20)
+        self.skin1 = SkinVisual.objects.create(
+            nome="Roupagem A",
+            tipo=SkinVisual.TIPO_AVATAR,
+            imagem="skins/a.png",
+            preco_moedas=10,
+            classe_restrita="mago",
+        )
+        self.skin2 = SkinVisual.objects.create(
+            nome="Roupagem B",
+            tipo=SkinVisual.TIPO_AVATAR,
+            imagem="skins/b.png",
+            preco_moedas=30,
+            classe_restrita="guerreiro",
+        )
+        SkinUsuario.objects.create(usuario=self.user, skin=self.skin1)
+
+    def test_loja_skins_view_info(self):
+        self.client.login(username="shop", password="123")
+        response = self.client.get(reverse("loja_skins"))
+        self.assertEqual(response.status_code, 200)
+        infos = list(response.context["skins_info"])
+        self.assertEqual(len(infos), 2)
+
+        info1 = next(i for i in infos if i["skin"] == self.skin1)
+        self.assertTrue(info1["ja_possui"])
+        self.assertFalse(info1["pode_comprar"])
+
+        info2 = next(i for i in infos if i["skin"] == self.skin2)
+        self.assertFalse(info2["ja_possui"])
+        self.assertFalse(info2["pode_comprar"])
+
+

--- a/gulango_warrior/avatars/urls.py
+++ b/gulango_warrior/avatars/urls.py
@@ -4,6 +4,7 @@ from .views import (
     ranking_geral,
     destaque_conquistas,
     inventario_skins,
+    loja_skins,
 )
 
 urlpatterns = [
@@ -11,4 +12,5 @@ urlpatterns = [
     path('ranking/', ranking_geral, name='ranking_geral'),
     path('conquistas/', destaque_conquistas, name='destaque_conquistas'),
     path('inventario/', inventario_skins, name='inventario_skins'),
+    path('loja/', loja_skins, name='loja_skins'),
 ]

--- a/gulango_warrior/avatars/views.py
+++ b/gulango_warrior/avatars/views.py
@@ -4,7 +4,7 @@ from django.db.models import Count
 
 from progress.models import AvatarConquista
 
-from .models import Avatar, SkinUsuario
+from .models import Avatar, SkinUsuario, SkinVisual
 
 
 @login_required
@@ -63,4 +63,27 @@ def inventario_skins(request):
 
     context = {"skins_usuario": skins_usuario}
     return render(request, "avatars/inventario_skins.html", context)
+
+
+@login_required
+def loja_skins(request):
+    """Lista todas as skins disponíveis, indicando posse e possibilidade de compra."""
+
+    avatar = Avatar.objects.get(user=request.user)
+    skins = SkinVisual.objects.all().order_by("nome")
+
+    skins_info = []
+    for skin in skins:
+        ja_possui = SkinUsuario.objects.filter(usuario=request.user, skin=skin).exists()
+        classe_ok = skin.classe_restrita == "todas" or skin.classe_restrita == avatar.classe
+        moedas_ok = avatar.moedas >= skin.preco_moedas
+        pode_comprar = classe_ok and moedas_ok and not ja_possui
+        skins_info.append({
+            "skin": skin,
+            "ja_possui": ja_possui,
+            "pode_comprar": pode_comprar,
+        })
+
+    context = {"skins_info": skins_info, "avatar": avatar}
+    return render(request, "avatars/loja_skins.html", context)
 


### PR DESCRIPTION
## Summary
- add loja_skins view to display all available skins with purchase info
- expose loja_skins route
- create loja_skins template
- test new loja_skins view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_684caf6bce60832ab6491add0b8a3abd